### PR TITLE
feat(keyboard-input): Accept keyboard input to let the user type words

### DIFF
--- a/wordle-tutorial/src/App.tsx
+++ b/wordle-tutorial/src/App.tsx
@@ -1,24 +1,32 @@
-import React from 'react';
-import logo from './logo.svg';
+import { useEffect, useState } from 'react';
 import './App.css';
 
+const LETTERS = "abcdefghijklmnopqrstuvwxyz";
+
 function App() {
+  // The current word
+  const [buffer, setBuffer] = useState("");
+
+  useEffect(() => {
+    // Called every time the user presses a key on the page
+    const handler = (ev: KeyboardEvent) => {
+      if (ev.key === "Backspace" && buffer.length > 0) {
+        setBuffer(buffer.slice(0, -1));
+      } else if (LETTERS.includes(ev.key) && buffer.length < 5) {
+        setBuffer(buffer + ev.key);
+      }
+    };
+
+    // Register the handler defined above (and unregister it if we update it and need to re-register a new version)
+    document.addEventListener("keydown", handler);
+    return () => {
+      document.removeEventListener("keydown", handler)
+    };
+  }, [buffer]);
+
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+    <div>
+      <div>{buffer}</div>
     </div>
   );
 }


### PR DESCRIPTION
This PR lets users type words in using the key-press APIs. We're using key-press APIs (as opposed to an input) so that we can customize the display of the characters (as they need to be in their own box). One down-side of this is that this won't work on mobile (as the keyboard is hidden by default), but we can stack that on-top. 